### PR TITLE
update fire schema

### DIFF
--- a/ci/requirements-fire.yml
+++ b/ci/requirements-fire.yml
@@ -10,6 +10,7 @@ dependencies:
   - fuzzywuzzy
   - gcsfs
   - geopandas
+  - GitPython
   - mbutil
   - numpy
   - requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 
 [isort]
-known_third_party=bs4,censusgeocode,click,fsspec,fuzzywuzzy,geopandas,geopy,numpy,tenacity
+known_third_party=bs4,censusgeocode,click,fsspec,fuzzywuzzy,geopandas,geopy,git,numpy,tenacity
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Changes inclue:
- new name/created_datetime/git_sha fields in both files
- fire metadata now only includes fires that intersect projects so it will be a faster fetch.

Here's a sneak peak at what the schemas look like:

the `fire_meta.json` schema now looks like this:
```
{
	"name": "Fire metadata",
	"created_datetime": "2021-08-09T02:41:18.285560",
	"git_sha": "216deb8",
	"fires": {
		"2021-ORFWF-210321": {
			"name": "Bootleg",
			"url": "https://inciweb.nwcg.gov/incident/7609/",
			"start_date": "2021-07-06T20:42:00+00:00",
			"status": "",
			"centroid": [-121.08050733883158, 42.64644235975104],
			"label_geom": [-121.2339452, 42.902644523000085]
		},
```
and the `projects_with_fires.json` schema now looks like:
```
{
	"name": "Projects with fires",
	"created_datetime": "2021-08-09T02:41:18.285560",
	"git_sha": "216deb8",
	"projects": {
		"CAR1314": {
			"burned_frac": 0.009010027584778068,
			"overlapping_fires": ["2021-WASPA-002124"]
		},
```