### PR TITLE
Fix toggle

### DIFF
--- a/components/projects/filter.js
+++ b/components/projects/filter.js
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect, useContext } from 'react'
-import { Box, Text, Flex, Grid, Input } from 'theme-ui'
-import { Row, Column, Badge, Toggle } from '@carbonplan/components'
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { Box, Flex, Input } from 'theme-ui'
+import { Badge, Toggle } from '@carbonplan/components'
 
 const Filter = ({
   filters,
@@ -48,6 +48,10 @@ const Filter = ({
       return { ...filters, search: value }
     })
   }
+
+  const handleToggle = useCallback(() => {
+    hotspotsToggle ? setShowHotspots(!showHotspots) : toggle('updateWithMap')
+  }, [hotspotsToggle, toggle, setShowHotspots, showHotspots])
 
   return (
     <Box sx={{ pl: [3, 4, 5, 6], pr: [3, 5, 5, 6], py: [4], mb: [1] }}>
@@ -105,7 +109,7 @@ const Filter = ({
       >
         <Flex sx={{ mt: [2], minWidth: '200px' }}>
           <Box
-            onClick={() => toggle('updateWithMap')}
+            onClick={handleToggle}
             sx={{
               fontFamily: 'mono',
               letterSpacing: 'mono',
@@ -122,11 +126,7 @@ const Filter = ({
             {hotspotsToggle ? 'SHOW THERMAL HOTSPOTS' : 'UPDATE W/ MAP'}
           </Box>
           <Toggle
-            onClick={() =>
-              hotspotsToggle
-                ? setShowHotspots(!showHotspots)
-                : toggle('updateWithMap')
-            }
+            onClick={handleToggle}
             value={hotspotsToggle ? showHotspots : filters.updateWithMap}
             sx={{
               color: toggleColor,


### PR DESCRIPTION
The sidebar toggle has different behavior across routes. For `/research/forest-offsets-fires`, it toggles rendering FIRMS hotspots. For `/research/forest-offsets-crediting`, it toggles behavior that filters projects based on whether they're in view in the map. This filtering logic does not seem to work on the fire route and instead always returns an empty list (this is okay). 

This PR fixes an inconsistency that currently exists depending on whether you click on the toggle directly (correct switching logic) or click on the toggle label (always tries to filter projects). 